### PR TITLE
bugfix - Date

### DIFF
--- a/Hurd/View/TabBarViews/TripView.swift
+++ b/Hurd/View/TabBarViews/TripView.swift
@@ -19,10 +19,10 @@ struct TripView: View {
                 HurdSlidingTabView(selection: $vm.selection, tabs: ["Upcoming", "Past"], activeAccentColor: .black, selectionBarColor: .black)
                 switch vm.selection {
                 case 0:
-                    if vm.trips.isEmpty {
+                    if vm.trips.filter { ($0.tripEndDate + 86400) >= vm.currentDate }.isEmpty {
                         ProgressView()
                     } else {
-                        ForEach(vm.trips, id: \.id) { trip in
+                        ForEach(vm.trips.filter { ($0.tripEndDate + 86400) >= vm.currentDate }, id: \.id) { trip in
                             if let hurd = trip.hurd {
                                 NavigationLink(destination: {
                                     GroupPlannerView(vm: GroupPlannerViewModel(trip: trip, hurd: hurd))
@@ -36,10 +36,10 @@ struct TripView: View {
                         }
                     }
                 case 1:
-                    if vm.trips.filter { $0.tripEndDate < vm.currentDate }.isEmpty {
+                    if vm.trips.filter { ($0.tripEndDate + 86400) < vm.currentDate }.isEmpty {
                         ProgressView()
                     } else {
-                        ForEach(vm.trips.filter { $0.tripEndDate < vm.currentDate }, id: \.id) { trip in
+                        ForEach(vm.trips.filter { ($0.tripEndDate + 86400) < vm.currentDate }, id: \.id) { trip in
                             if let hurd = trip.hurd {
                                 NavigationLink(destination: {
                                     GroupPlannerView(vm: GroupPlannerViewModel(trip: trip, hurd: hurd))


### PR DESCRIPTION
Not sure if you still want to handle dates completely different or not, but this is at least a fix so the "Upcoming Trips" section shows only trips that haven't happened yet, and "Past Trips" section will be all past trips. Previously, "Past Trips" would contain trips with tripEndDate's that are equal to currentDate, now they don't appear in Past Trips until they are past the current date. Also, "Upcoming Trips" was showing all trips, even trips that were in "Past Trips".