### PR TITLE
Location List Disappears

### DIFF
--- a/Hurd/View/AddTripFormView.swift
+++ b/Hurd/View/AddTripFormView.swift
@@ -10,7 +10,7 @@ struct AddTripFormView: View {
     @ObservedObject var vm: AddTripFormViewModel
     
     var body: some View {
-    Form {
+        Form {
             Section(vm.formType == .edit ? "Edit Trip": "Add Trip") {
                 TextField("Trip Name", text: $vm.tripNameText)
             }
@@ -19,28 +19,23 @@ struct AddTripFormView: View {
             Section("Trip Location") {
                 ZStack(alignment: .trailing) {
                     TextField("Trip Location", text: $vm.tripLocationSearchQuery)
-                    if vm.status == .isSearching {
+                    if vm.locationStatus != .selected {
                         Image(systemName: "clock")
                             .foregroundColor(.gray)
                     }
                     
                 }
-            }
-            
-            if vm.status == .result && !vm.searchResults.isEmpty {
-                List {
-                    ForEach(vm.searchResults, id: \.self) { resultItem in
-                        
-                        Button {
-                            vm.selectedLocation()
-                            vm.tripLocationSearchQuery = "\(resultItem.title), \(resultItem.subtitle)"
-                            
-                            // make a call to grab lat and long, based off title and subtitle of resul Item Object
-                            
-                        } label: {
-                            Text("\(resultItem.title), \(resultItem.subtitle)")
+                
+                if vm.locationStatus != .selected {
+                    List {
+                        ForEach(vm.searchResults, id: \.self) { resultItem in
+                            Button {
+                                vm.selectedLocation(resultItem)
+                                // make a call to grab lat and long, based off title and subtitle of resul Item Object
+                            } label: {
+                                Text("\(resultItem.title), \(resultItem.subtitle)")
+                            }
                         }
-                        
                     }
                 }
             }

--- a/Hurd/ViewModel/AddTripFormViewModel.swift
+++ b/Hurd/ViewModel/AddTripFormViewModel.swift
@@ -21,6 +21,7 @@ class AddTripFormViewModel: NSObject, ObservableObject {
     @Published var tripCostEstimate: Double = 0
     
     @Published private(set) var status: SearchStatus = .idle
+    @Published private(set) var locationStatus: LocationStatus = .notSelected
     @Published private(set) var searchResults: [MKLocalSearchCompletion] = []
     @Published var tripStartDate = Date.now
     @Published var tripEndDate: Date = Date.now
@@ -56,6 +57,11 @@ class AddTripFormViewModel: NSObject, ObservableObject {
         case result
     }
     
+    enum LocationStatus {
+        case notSelected
+        case selected
+    }
+    
     enum TripType: String {
         case vacation
         case cruise
@@ -89,8 +95,10 @@ class AddTripFormViewModel: NSObject, ObservableObject {
                 }
         })
     }
-    func selectedLocation() {
+    func selectedLocation(_ location: MKLocalSearchCompletion) {
         self.status = .idle
+        self.locationStatus = .selected
+        self.tripLocationSearchQuery = "\(location.title), \(location.subtitle)"
     }
     
     func prepopulateValuesFrom(current trip: Trip) {


### PR DESCRIPTION
These are the changes I made to get the result we wanted, however I am still concerned about the Post Trip bug.

If you run the main branch right now, and fill out a Trip in the Add Trip Form, once you press the "Post Trip" button it will not save the trip you just tried to make. The app doesn't crash, but you will not see the trip in the Upcoming tab or in the Past tab.

If you run this new branch I made just now, and fill out a Trip in the Add Trip Form, once you press the "Post Trip" button it will not save the trip and the app does crash.

I can provide a screenshot of the Fatal Error it provides and where it is triggered, but it is within a function that I don't even change in this branch. It sounds like its an issue with however this View Model saves trips, like on the main thread something is still needing changed. Because I feel as though the approach I took on this to make the List disappear is truly the simplest approach that I would know how to do.

In your SearchStatus enum, you handle all of those cases in a pretty advanced way that it didn't make sense to use those cases to reflect what a View should be. It would work out, except it appears that even though we set the status after clicking on a location, the TextField changes it's status once again a second after the list disappears, because it thinks the User is still actively typing in the TextField. So I figured, let's not use this to determine whether or not the List should show:

if vm.status == .result && !vm.searchResults.isEmpty {
     // List
}

Instead, make another Enum (could have just used a Boolean but figured this was easier to read and does the same) that only has "notSelected" and "selected" for cases. Then, when we press on a List and trigger this function (which I changed slightly from your original) also have it set a variable 'locationStatus' to be '.selected' instead of its default '.notSelected', so we can call for the List this way:

if vm.locationStatus != .selected {
    // List
}