### PR TITLE
Dark Mode fix

### DIFF
--- a/Hurd/Assets.xcassets/Colors/Contents.json
+++ b/Hurd/Assets.xcassets/Colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Hurd/Assets.xcassets/Colors/backgroundColor.colorset/Contents.json
+++ b/Hurd/Assets.xcassets/Colors/backgroundColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Hurd/Assets.xcassets/Colors/textColor.colorset/Contents.json
+++ b/Hurd/Assets.xcassets/Colors/textColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x00",
+          "green" : "0x00",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xFF",
+          "red" : "0xFF"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Hurd/View/GroupPlannerView.swift
+++ b/Hurd/View/GroupPlannerView.swift
@@ -26,7 +26,7 @@ struct GroupPlannerView: View {
                         .scaledToFill()
                         .frame(width: 350)
                         .overlay {
-                            Color.black.opacity(0.2)
+                            Color("textColor").opacity(0.2)
                         }
                     
                     HStack(alignment: .bottom) {
@@ -43,9 +43,9 @@ struct GroupPlannerView: View {
                                 .padding(.bottom,10)
                             
                             Image(systemName: "car.fill")
-                                .foregroundColor(.white)
+                                .foregroundColor(Color("backgroundColor"))
                                 .padding()
-                                .background(Circle().fill(.black))
+                                .background(Circle().fill(Color("textColor")))
                             
                             Spacer()
                         }
@@ -71,7 +71,7 @@ struct GroupPlannerView: View {
 
                     Text("$\(vm.trip.tripCostString)/PP")
                         .font(.system(size: 14))
-                        .foregroundColor(.black.opacity(0.7))
+                        .foregroundColor(Color("textColor").opacity(0.7))
                         .padding(10)
                         .fontWeight(.bold)
                         .background(RoundedRectangle(cornerRadius: 10).fill(.gray.opacity(0.2)))
@@ -80,14 +80,14 @@ struct GroupPlannerView: View {
                 Divider()
                 HStack {
                     Image(systemName: "speaker.wave.3.fill")
-                        .foregroundColor(.white)
+                        .foregroundColor(Color("backgroundColor"))
                         .padding()
-                        .background(Circle().fill(.black))
+                        .background(Circle().fill(Color("textColor")))
                     
                     Image(systemName: "list.bullet.clipboard.fill")
-                        .foregroundColor(.white)
+                        .foregroundColor(Color("backgroundColor"))
                         .padding()
-                        .background(Circle().fill(.black))
+                        .background(Circle().fill(Color("textColor")))
                     
                     NavigationLink {
                         TripNotesView(vm: vm)
@@ -95,14 +95,14 @@ struct GroupPlannerView: View {
                         ZStack(alignment: .topTrailing) {
                             Image(systemName: "note")
                                 .badge(20)
-                                .foregroundColor(.white)
+                                .foregroundColor(Color("backgroundColor"))
                                 .padding()
-                                .background(Circle().fill(.black))
+                                .background(Circle().fill(Color("textColor")))
                             
                             if let noteCount = vm.notes?.count, noteCount > 0 {
                                 Text("\(noteCount)")
                                     .padding(3)
-                                    .foregroundColor(.white)
+                                    .foregroundColor(Color("backgroundColor"))
                                     .font(.system(size: 14))
                                     .frame(width: 25)
                                     .background(RoundedRectangle(cornerRadius: 8).fill(.orange))
@@ -114,9 +114,9 @@ struct GroupPlannerView: View {
                     
                     
                     Image(systemName: "square.and.arrow.up")
-                        .foregroundColor(.white)
+                        .foregroundColor(Color("backgroundColor"))
                         .padding()
-                        .background(Circle().fill(.black))
+                        .background(Circle().fill(Color("textColor")))
                 }
                 Divider()
                             
@@ -125,15 +125,15 @@ struct GroupPlannerView: View {
                         .resizable()
                         .frame(width: 50, height: 50)
                         .clipShape(Circle())
-                        .background(Circle().stroke(Color.black.opacity(0.5), lineWidth: 10))
+                        .background(Circle().stroke(Color("textColor").opacity(0.5), lineWidth: 10))
                         .padding(.vertical, 10)
                     
                     Spacer()
                     
                     Image(systemName: "plus")
-                        .foregroundColor(.white)
+                        .foregroundColor(Color("backgroundColor"))
                         .padding(10)
-                        .background(Circle().fill(.black))
+                        .background(Circle().fill(Color("textColor")))
                 }
             
                 NavigationLink("",

--- a/Hurd/View/HurdPasswordTextField.swift
+++ b/Hurd/View/HurdPasswordTextField.swift
@@ -22,7 +22,7 @@ struct HurdPasswordTextField: View {
                 } label: {
                     showPassword ? Image(systemName: "eye") : Image(systemName: "eye.slash")
                 }
-                .tint(.black)
+                .tint(Color("textColor"))
             } else {
                 SecureField(placeholderText, text: $text)
                 Button {
@@ -30,7 +30,7 @@ struct HurdPasswordTextField: View {
                 } label: {
                     showPassword ? Image(systemName: "eye") : Image(systemName: "eye.slash")
                 }
-                .tint(.black)
+                .tint(Color("textColor"))
             }
         }
         .frame(height: 40)

--- a/Hurd/View/HurdSlidingTabView.swift
+++ b/Hurd/View/HurdSlidingTabView.swift
@@ -65,7 +65,7 @@ struct HurdSlidingTabView: View {
                 font: Font = .body,
                 animation: Animation = .spring(),
                 activeAccentColor: Color = .blue,
-                inactiveAccentColor: Color = Color.black.opacity(0.4),
+                inactiveAccentColor: Color = Color("textColor").opacity(0.4),
                 selectionBarColor: Color = .blue,
                 inactiveTabColor: Color = .clear,
                 activeTabColor: Color = .clear,

--- a/Hurd/View/NoTripView.swift
+++ b/Hurd/View/NoTripView.swift
@@ -17,11 +17,13 @@ struct NoTripView: View {
         VStack {
             Text("No Trips")
                 .font(.largeTitle)
+                .foregroundColor(.black)
                 .bold()
                 .padding(.bottom, Spacing.sixteen)
             
             Text(isPastTrip ? noPastTripMsg : noCurrentTripMsg)
                 .multilineTextAlignment(.center)
+                .foregroundColor(.black)
         }
         .padding()
         .background(RoundedRectangle(cornerRadius: 10).fill(.white).shadow(color: .gray.opacity(0.2), radius: 5, x: 5, y: 5))

--- a/Hurd/View/NotesView.swift
+++ b/Hurd/View/NotesView.swift
@@ -49,6 +49,7 @@ struct NotesView: View {
                     Text(note.title)
                         .font(.system(size: 17))
                         .fontWeight(.semibold)
+                        .foregroundColor(.black)
                     
                     Spacer()
                     

--- a/Hurd/View/TabBarViews/TripView.swift
+++ b/Hurd/View/TabBarViews/TripView.swift
@@ -17,7 +17,7 @@ struct TripView: View {
     var body: some View {
         NavigationView {
             VStack {
-                HurdSlidingTabView(selection: $vm.selection, tabs: ["Upcoming", "Past"], activeAccentColor: .black, selectionBarColor: .black)
+                HurdSlidingTabView(selection: $vm.selection, tabs: ["Upcoming", "Past"], activeAccentColor: Color("textColor"), selectionBarColor: Color("textColor"))
                 ScrollView {
                     switch vm.selection {
                     case 0:
@@ -71,9 +71,9 @@ struct TripView: View {
                             addTripVM.addTripFormPresented = true
                         } label: {
                             Image(systemName: "plus")
-                                .foregroundColor(.white)
+                                .foregroundColor(Color("backgroundColor"))
                                 .padding(5)
-                                .background(Circle().fill(.black))
+                                .background(Circle().fill(Color("textColor")))
                         }
                     }
                 }

--- a/Hurd/View/TagView.swift
+++ b/Hurd/View/TagView.swift
@@ -14,10 +14,10 @@ struct TagView: View {
     var body: some View {
         Text(tagName)
             .font(.caption2)
-            .foregroundColor(.white)
+            .foregroundColor(Color("backgroundColor"))
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
-            .background(Capsule().fill(.black))
+            .background(Capsule().fill(Color("textColor")))
     }
 }
 

--- a/Hurd/View/TripDateView.swift
+++ b/Hurd/View/TripDateView.swift
@@ -14,13 +14,15 @@ struct TripDateView: View {
         VStack {
             Text(returnDateNumber())
                 .font(.system(size: 25))
+                .foregroundColor(Color("textColor"))
                 .fontWeight(.bold)
+            
             Text(returnDateMonth().uppercased())
-                
+                .foregroundColor(Color("textColor"))
         }
         .padding(10)
         .background(
-            RoundedRectangle(cornerRadius: 10).fill(.white)
+            RoundedRectangle(cornerRadius: 10).fill(Color("backgroundColor"))
                 .shadow(color: .gray.opacity(0.3), radius: 5, x: 3, y: 3))
     }
     

--- a/Hurd/View/TripNotesView.swift
+++ b/Hurd/View/TripNotesView.swift
@@ -14,7 +14,7 @@ struct TripNotesView: View {
     var body: some View {
         VStack(spacing: 10) {
             HStack(spacing: 20) {
-                HurdSlidingTabView(selection: $selection, tabs: ["Important","general"])
+                HurdSlidingTabView(selection: $selection, tabs: ["Important","general"], activeAccentColor: Color("textColor"), selectionBarColor: Color("textColor"))
                     //.padding(.trailing, 130)
             }
            
@@ -34,9 +34,9 @@ struct TripNotesView: View {
                     vm.showAddNoteForm = true
                 } label: {
                     Image(systemName: "plus")
-                        .foregroundColor(.white)
+                        .foregroundColor(Color("backgroundColor"))
                         .padding(5)
-                        .background(Circle().fill(.black))
+                        .background(Circle().fill(Color("textColor")))
                 }
 
             }

--- a/Hurd/View/TripPreviewView.swift
+++ b/Hurd/View/TripPreviewView.swift
@@ -25,7 +25,7 @@ struct TripPreviewView: View {
                     .frame(width: UIScreen.main.bounds.width * 0.9)
                     .scaledToFill()
                     .overlay {
-                        Color.black.opacity(0.2)
+                        Color("textColor").opacity(0.2)
                     }
                 
                 HStack(alignment: .top) {
@@ -35,7 +35,7 @@ struct TripPreviewView: View {
                                 .resizable()
                                 .frame(width: 40, height: 40)
                                 .clipShape(Circle())
-                                .background(Circle().stroke(Color.white, lineWidth: 5))
+                                .background(Circle().stroke(Color("backgroundColor"), lineWidth: 5))
                                 .padding()
                         }) {
                             Circle()
@@ -49,7 +49,7 @@ struct TripPreviewView: View {
                         Circle()
                             .fill(.gray)
                             .frame(width: 60, height: 60)
-                            .background(Circle().stroke(Color.black, lineWidth: 8))
+                            .background(Circle().stroke(Color("textColor"), lineWidth: 8))
                             .padding()
                     }
                     
@@ -65,9 +65,9 @@ struct TripPreviewView: View {
                         Spacer()
                         
                         Image(systemName: trip.iconName)
-                            .foregroundColor(.white)
+                            .foregroundColor(Color("backgroundColor"))
                             .padding()
-                            .background(Circle().fill(.black))
+                            .background(Circle().fill(Color("textColor")))
                     }
                     .padding()
                 }
@@ -79,7 +79,7 @@ struct TripPreviewView: View {
             
             Text(trip.tripName)
                 .font(.system(size: 25))
-                .foregroundColor(.black)
+                .foregroundColor(Color("textColor"))
                 .fontWeight(.bold)
             
             Label(trip.tripDestination, systemImage: "mappin")


### PR DESCRIPTION
I added two color sets into your assets:
"textColor" - refers to the color that Text would naturally be in each mode
"backgroundColor" - refers to the color that the background would naturally be in each mode

All views are now visible when in dark mode, and all the views you had created still look the same when in light mode. Appearance only changes when in dark mode for certain views.

I did happen to change one other thing in this branch. The HurdSlidingTabView that gets called in TripView didn't have the same modifiers as the HurdSlidingTabView that gets called in TripNotesView, so I fixed the one that was missing the changes. Now they appear the same in both views, like you were intending.