### PR TITLE
fixed primary hurd button

### DIFF
--- a/Hurd/View/Onboarding/OnboardingProfileInfoView.swift
+++ b/Hurd/View/Onboarding/OnboardingProfileInfoView.swift
@@ -92,6 +92,7 @@ struct OnboardingProfileInfoView: View {
                 HStack {
                     Text("Select Your Gender:")
                         .foregroundColor(.gray)
+                        .padding(.horizontal)
                     
                     Spacer()
                     

--- a/Hurd/View/PrimaryHurdButton.swift
+++ b/Hurd/View/PrimaryHurdButton.swift
@@ -21,6 +21,9 @@ struct PrimaryHurdButton: View {
                         .foregroundColor((buttonModel.buttonType == .primary) ? .white : Color.bottleGreen)
                     
                 }
+                .frame(maxWidth: .infinity) // Added this to make the entire HStack clickable
+                // Otherwise only the Text is tappable
+                
                 if buttonModel.icon != nil {
                     HStack {
                         if buttonModel.appendingIcon ?? false {


### PR DESCRIPTION
- Added horizontal padding for Text("Select Your Gender") in the Onboarding View, it was touching the edge of the RoundedRectangle() background

- Made it so everywhere you use the PrimaryHurdButton view the entire button is tappable instead of just the Text, did this by setting the width of the HStack to .infinity